### PR TITLE
Feat: implements upload event for when a src variable is updated

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -3,7 +3,8 @@ import type {
 	IParsedEditSchema,
 	IShotstackEvents,
 	IShotstackHandlers,
-	MergeField
+	MergeField,
+	UploadCallback
 } from './types';
 import { validateError, validateTemplate, stringifyIfNotString } from './validate';
 
@@ -17,7 +18,7 @@ export class ShotstackEditTemplateService {
 		this._error = null;
 		this.template = { merge: [] };
 		this._result = { merge: [] };
-		this.handlers = { change: [], submit: [], error: [this.logger] };
+		this.handlers = { change: [], submit: [], error: [this.logger], upload: [] };
 		this.setTemplateSource(template);
 	}
 
@@ -114,7 +115,6 @@ export class ShotstackEditTemplateService {
 	getSrcPlaceholders(): { placeholder: string; asset: Asset }[] {
 		if (!this.template.tracks) return [];
 		const result: { placeholder: string; asset: Asset }[] = [];
-
 		for (let i = 0; i < this.template.tracks.length; i++) {
 			for (let j = 0; j < this.template.tracks[i].clips.length; j++) {
 				const key = {
@@ -125,5 +125,14 @@ export class ShotstackEditTemplateService {
 			}
 		}
 		return result;
+	}
+
+	updateSrc(asset: Asset) {
+		const url: string = this.handlers.upload.reduce(
+			(acc: string, curr: UploadCallback) => curr(),
+			''
+		);
+		asset.src = url;
+		this.handlers.change.forEach((fn) => fn(this.result));
 	}
 }

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -15,15 +15,17 @@ export interface IParsedEditSchema {
 	tracks?: Track[];
 }
 
-export type TemplateEvent = 'submit' | 'change' | 'error';
+export type TemplateEvent = 'submit' | 'change' | 'error' | 'upload';
 export type ResultTemplateCallback = (resultTemplate: IParsedEditSchema) => void;
 export type ErrorCallback = (err: unknown, previousError?: unknown) => void;
 export type SubmitCallback = (resultTemplate: IParsedEditSchema) => void;
+export type UploadCallback = () => string;
 
 export interface IShotstackEvents {
 	change: ResultTemplateCallback;
 	submit: SubmitCallback;
 	error: ErrorCallback;
+	upload: UploadCallback;
 }
 
 type ShotstackHandlersArray<T, K extends keyof T> = T[K][];


### PR DESCRIPTION
# Summary
- Adds a upload event that triggers whenever there's an update on an asset
- Upload callbacks should return a string, the last of which is assigned to the asset and updates its corresponding value.
- This update also triggers change events

# Evidence
![image](https://user-images.githubusercontent.com/55909151/199869433-0030cc86-147c-41ec-bc0f-2592beae98fb.png)
![image](https://user-images.githubusercontent.com/55909151/199869449-2071592f-c38e-4d53-9152-36e682e32d9b.png)
