### PR TITLE
Bugfix: upload callback function now receives a filelist. Updates types

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -140,7 +140,9 @@ describe('ShotstackEditTemplateService.getSrcPlaceholders', () => {
 		const local = { src: 'http://localhost' };
 		const editTemplateService = new ShotstackEditTemplateService({
 			merge: [{ find: 'NAME', replace: 'John' }],
-			tracks: [{ clips: [{ asset }, { asset: local }] }]
+			timeline: {
+				tracks: [{ clips: [{ asset }, { asset: local }] }]
+			}
 		});
 		const result = editTemplateService.getSrcPlaceholders();
 		expect(result).toEqual([{ placeholder: asset.src, asset }]);

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -113,13 +113,14 @@ export class ShotstackEditTemplateService {
 	}
 
 	getSrcPlaceholders(): { placeholder: string; asset: Asset }[] {
-		if (!this.template.tracks) return [];
+		if (!this.template.timeline || !this.template.timeline.tracks) return [];
+		const tracks = this.template.timeline.tracks;
 		const result: { placeholder: string; asset: Asset }[] = [];
-		for (let i = 0; i < this.template.tracks.length; i++) {
-			for (let j = 0; j < this.template.tracks[i].clips.length; j++) {
+		for (let i = 0; i < tracks.length; i++) {
+			for (let j = 0; j < tracks[i].clips.length; j++) {
 				const key = {
-					placeholder: this.template.tracks[i].clips[j].asset.src,
-					asset: this.template.tracks[i].clips[j].asset
+					placeholder: tracks[i].clips[j].asset.src,
+					asset: tracks[i].clips[j].asset
 				};
 				if (key.placeholder.charAt(0) === '{') result.push(key);
 			}

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -18,7 +18,12 @@ export class ShotstackEditTemplateService {
 		this._error = null;
 		this.template = { merge: [] };
 		this._result = { merge: [] };
-		this.handlers = { change: [], submit: [], error: [this.logger], upload: [] };
+		this.handlers = {
+			change: [],
+			submit: [],
+			error: [this.logger],
+			upload: []
+		};
 		this.setTemplateSource(template);
 	}
 
@@ -128,9 +133,9 @@ export class ShotstackEditTemplateService {
 		return result;
 	}
 
-	updateSrc(asset: Asset) {
+	updateSrc(files: FileList | null, asset: Asset) {
 		const url: string = this.handlers.upload.reduce(
-			(acc: string, curr: UploadCallback) => curr(),
+			(acc: string, curr: UploadCallback) => curr(files),
 			''
 		);
 		asset.src = url;

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -10,9 +10,9 @@ export interface MergeField {
 }
 
 export interface IParsedEditSchema {
+	timeline?: Timeline;
 	merge: MergeField[];
 	[key: string]: unknown;
-	tracks?: Track[];
 }
 
 export type TemplateEvent = 'submit' | 'change' | 'error' | 'upload';
@@ -46,5 +46,10 @@ export type Asset = {
 
 export type Track = {
 	clips: Clip[];
+	[key: string]: unknown;
+};
+
+export type Timeline = {
+	tracks: Track[];
 	[key: string]: unknown;
 };

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -19,7 +19,7 @@ export type TemplateEvent = 'submit' | 'change' | 'error' | 'upload';
 export type ResultTemplateCallback = (resultTemplate: IParsedEditSchema) => void;
 export type ErrorCallback = (err: unknown, previousError?: unknown) => void;
 export type SubmitCallback = (resultTemplate: IParsedEditSchema) => void;
-export type UploadCallback = () => string;
+export type UploadCallback = (files: FileList | null) => string;
 
 export interface IShotstackEvents {
 	change: ResultTemplateCallback;


### PR DESCRIPTION
# Summary
- Updated typing according to shotstack schema, now following complete type dependency from timeline to asset
- Updated upload callback specifications: now is provided a filelist and must return a string to update the template

# Evidence
![image](https://user-images.githubusercontent.com/55909151/199877184-4afbaf1d-1ba2-4b26-a436-4ecefa3983fb.png)
![image](https://user-images.githubusercontent.com/55909151/199877195-44e45d5e-ca8b-4175-8b5a-ae3ab6c71dde.png)

