### PR TITLE
Feat: implements sourcefields component

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -136,7 +136,7 @@ export class ShotstackEditTemplateService {
 	updateSrc(files: FileList | null, asset: Asset) {
 		const url: string = this.handlers.upload.reduce(
 			(acc: string, curr: UploadCallback) => curr(files),
-			''
+			asset.src
 		);
 		asset.src = url;
 		this.handlers.change.forEach((fn) => fn(this.result));

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -127,7 +127,7 @@ export class ShotstackEditTemplateService {
 					placeholder: tracks[i].clips[j].asset.src,
 					asset: tracks[i].clips[j].asset
 				};
-				if (key.placeholder.charAt(0) === '{') result.push(key);
+				if (key.placeholder !== undefined && key.placeholder.charAt(0) === '{') result.push(key);
 			}
 		}
 		return result;

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -3,8 +3,7 @@ import type {
 	IParsedEditSchema,
 	IShotstackEvents,
 	IShotstackHandlers,
-	MergeField,
-	UploadCallback
+	MergeField
 } from './types';
 import { validateError, validateTemplate, stringifyIfNotString } from './validate';
 
@@ -133,12 +132,13 @@ export class ShotstackEditTemplateService {
 		return result;
 	}
 
-	updateSrc(files: FileList | null, asset: Asset) {
-		const url: string = this.handlers.upload.reduce(
-			(acc: string, curr: UploadCallback) => curr(files),
-			asset.src
-		);
-		asset.src = url;
+	async updateSrc(files: FileList | null, asset: Asset) {
+		let result = asset.src;
+		for (let i = 0; i < this.handlers.upload.length; i++) {
+			const handler = this.handlers.upload[i];
+			result = await handler(files);
+		}
+		asset.src = result;
 		this.handlers.change.forEach((fn) => fn(this.result));
 	}
 }

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -19,7 +19,7 @@ export type TemplateEvent = 'submit' | 'change' | 'error' | 'upload';
 export type ResultTemplateCallback = (resultTemplate: IParsedEditSchema) => void;
 export type ErrorCallback = (err: unknown, previousError?: unknown) => void;
 export type SubmitCallback = (resultTemplate: IParsedEditSchema) => void;
-export type UploadCallback = (files: FileList | null) => string;
+export type UploadCallback = (files: FileList | null) => Promise<string>;
 
 export interface IShotstackEvents {
 	change: ResultTemplateCallback;

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -145,25 +145,39 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
         </div>
          
         <div
-          data-cy="source-input"
+          data-cy="source-container"
         >
-          <label
-            class="block mb-2 monospace"
-            for="input"
+          <h1
+            class="text-teal-400 px-1"
           >
-            Upload src
-          </label>
+            Update sources
+          </h1>
            
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            disabled=""
-            type="text"
-          />
-           
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            type="file"
-          />
+          <div
+            class="border p-4 mb-6"
+          >
+            <div
+              data-cy="source-input"
+            >
+              <label
+                class="block mb-2 monospace"
+                for="input"
+              >
+                ASSET
+              </label>
+               
+              <input
+                class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                disabled=""
+                type="text"
+              />
+               
+              <input
+                class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                type="file"
+              />
+            </div>
+          </div>
         </div>
       </form>
        
@@ -207,7 +221,8 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
             "asset": {
               "type": "title",
               "text": "Hello {{ NAME }}",
-              "style": "future"
+              "style": "future",
+              "src": "{{ ASSET }}"
             },
             "start": 0,
             "length": 5
@@ -401,25 +416,39 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
         </div>
          
         <div
-          data-cy="source-input"
+          data-cy="source-container"
         >
-          <label
-            class="block mb-2 monospace"
-            for="input"
+          <h1
+            class="text-teal-400 px-1"
           >
-            Upload src
-          </label>
+            Update sources
+          </h1>
            
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            disabled=""
-            type="text"
-          />
-           
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            type="file"
-          />
+          <div
+            class="border p-4 mb-6"
+          >
+            <div
+              data-cy="source-input"
+            >
+              <label
+                class="block mb-2 monospace"
+                for="input"
+              >
+                ASSET
+              </label>
+               
+              <input
+                class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                disabled=""
+                type="text"
+              />
+               
+              <input
+                class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                type="file"
+              />
+            </div>
+          </div>
         </div>
       </form>
        
@@ -463,7 +492,8 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
             "asset": {
               "type": "title",
               "text": "Hello {{ NAME }}",
-              "style": "future"
+              "style": "future",
+              "src": "{{ ASSET }}"
             },
             "start": 0,
             "length": 5
@@ -657,25 +687,39 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
         </div>
          
         <div
-          data-cy="source-input"
+          data-cy="source-container"
         >
-          <label
-            class="block mb-2 monospace"
-            for="input"
+          <h1
+            class="text-teal-400 px-1"
           >
-            Upload src
-          </label>
+            Update sources
+          </h1>
            
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            disabled=""
-            type="text"
-          />
-           
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            type="file"
-          />
+          <div
+            class="border p-4 mb-6"
+          >
+            <div
+              data-cy="source-input"
+            >
+              <label
+                class="block mb-2 monospace"
+                for="input"
+              >
+                ASSET
+              </label>
+               
+              <input
+                class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                disabled=""
+                type="text"
+              />
+               
+              <input
+                class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                type="file"
+              />
+            </div>
+          </div>
         </div>
       </form>
        
@@ -719,7 +763,8 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
             "asset": {
               "type": "title",
               "text": "Hello {{ NAME }}",
-              "style": "future"
+              "style": "future",
+              "src": "{{ ASSET }}"
             },
             "start": 0,
             "length": 5
@@ -876,24 +921,16 @@ exports[`Testing Shotstack module entry point Shotstack.renderForm() should depl
         </div>
          
         <div
-          data-cy="source-input"
+          data-cy="source-container"
         >
-          <label
-            class="block mb-2 monospace"
-            for="input"
+          <h1
+            class="text-teal-400 px-1"
           >
-            Upload src
-          </label>
+            Update sources
+          </h1>
            
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            disabled=""
-            type="text"
-          />
-           
-          <input
-            class="border w-full mb-3 pl-2 py-1 text-stone-500"
-            type="file"
+          <div
+            class="border p-4 mb-6"
           />
         </div>
       </form>

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -921,6 +921,7 @@ exports[`Testing Shotstack module entry point Shotstack.renderForm() should depl
         </div>
          
         <div
+          class="hidden"
           data-cy="source-container"
         >
           <h1

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -78,8 +78,8 @@
 		error = editTemplateService.error;
 	}
 
-	function handleSourceFieldUpdate(file: FileList | null, asset: Asset) {
-		editTemplateService.updateSrc(file, asset);
+	async function handleSourceFieldUpdate(file: FileList | null, asset: Asset) {
+		await editTemplateService.updateSrc(file, asset);
 		template = editTemplateService.template;
 		result = editTemplateService.result;
 	}

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -5,23 +5,25 @@
 	import copyRegular from './copy-regular.svg';
 	import { ShotstackEditTemplateService } from '../../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './defaultMerge.json';
-	import type { IParsedEditSchema, MergeField } from '$lib/ShotstackEditTemplate/types';
+	import type { Asset, IParsedEditSchema, MergeField } from '$lib/ShotstackEditTemplate/types';
 	import SubmitArea from './submit/SubmitArea.svelte';
 	import Fields from './fields/Fields.svelte';
 	import ErrorField from './error/ErrorField.svelte';
-	import Source from './source/Source.svelte';
+	import SourceFields from './source/SourceFields.svelte';
 
 	export let editTemplateService = new ShotstackEditTemplateService(defaultJSONInput);
 
 	let template = editTemplateService.template;
 	let result = editTemplateService.result;
 	let error: Error | null = null;
+	let sources = editTemplateService.getSrcPlaceholders();
 
 	function handleTemplateInput(value: string) {
 		editTemplateService.setTemplateSource(value);
 		template = editTemplateService.template;
 		result = editTemplateService.result;
 		error = editTemplateService.error;
+		sources = editTemplateService.getSrcPlaceholders();
 	}
 
 	function handleFormInput(mergeField: MergeField, fieldReference?: MergeField) {
@@ -75,6 +77,12 @@
 		result = editTemplateService.result;
 		error = editTemplateService.error;
 	}
+
+	function handleSourceFieldUpdate(file: FileList | null, asset: Asset) {
+		editTemplateService.updateSrc(file, asset);
+		template = editTemplateService.template;
+		result = editTemplateService.result;
+	}
 </script>
 
 <div class="shotstack-mergefield-form">
@@ -93,7 +101,7 @@
 
 			<ErrorField {error} onClick={resetSourceTemplate} />
 			<Fields fields={result.merge} {handleFormInput} {addField} {removeField} {error} />
-			<Source />
+			<SourceFields {sources} {handleSourceFieldUpdate} />
 		</form>
 
 		{#if !error}

--- a/src/lib/components/Form/defaultMerge.json
+++ b/src/lib/components/Form/defaultMerge.json
@@ -13,7 +13,8 @@
 						"asset": {
 							"type": "title",
 							"text": "Hello {{ NAME }}",
-							"style": "future"
+							"style": "future",
+							"src": "{{ ASSET }}"
 						},
 						"start": 0,
 						"length": 5

--- a/src/lib/components/Form/source/Source.svelte
+++ b/src/lib/components/Form/source/Source.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
 	let urlFile = '';
-
-	function handleChange(event: FileList | null) {
-		if (!event) return;
-		urlFile = event.item(0)?.name || '';
-	}
+	export let label: string;
+	export let handleChange: (files: FileList | null) => void;
 </script>
 
 <div data-cy="source-input">
-	<label class="block mb-2 monospace" for="input">Upload src</label>
+	<label class="block mb-2 monospace" for="input">{label.slice(2, -2).trim()}</label>
 	<input class="border w-full mb-3 pl-2 py-1 text-stone-500" type="text" value={urlFile} disabled />
-
 	<input
 		on:change={(e) => handleChange(e.currentTarget.files)}
 		class="border w-full mb-3 pl-2 py-1 text-stone-500"

--- a/src/lib/components/Form/source/Source.svelte
+++ b/src/lib/components/Form/source/Source.svelte
@@ -1,14 +1,25 @@
 <script lang="ts">
-	let urlFile = '';
+	import type { Asset } from '../../../ShotstackEditTemplate/types';
+	export let asset: Asset;
+	export let value: string;
 	export let label: string;
-	export let handleChange: (files: FileList | null) => void;
+	export let handleChange: (files: FileList | null) => Promise<void>;
+	let loading = false;
+	$: disabled = loading;
+	let loadFile = async (files: FileList | null) => {
+		loading = true;
+		await handleChange(files);
+		value = asset.src;
+		loading = false;
+	};
 </script>
 
 <div data-cy="source-input">
 	<label class="block mb-2 monospace" for="input">{label.slice(2, -2).trim()}</label>
-	<input class="border w-full mb-3 pl-2 py-1 text-stone-500" type="text" value={urlFile} disabled />
+	<input class="border w-full mb-3 pl-2 py-1 text-stone-500" type="text" {value} disabled />
 	<input
-		on:change={(e) => handleChange(e.currentTarget.files)}
+		{disabled}
+		on:change={(e) => loadFile(e.currentTarget.files)}
 		class="border w-full mb-3 pl-2 py-1 text-stone-500"
 		type="file"
 	/>

--- a/src/lib/components/Form/source/SourceFields.svelte
+++ b/src/lib/components/Form/source/SourceFields.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { Asset } from '$lib/ShotstackEditTemplate/types';
+	import Source from './Source.svelte';
+	export let sources: { placeholder: string; asset: Asset }[];
+	export let handleSourceFieldUpdate: (files: FileList | null, asset: Asset) => void;
+	const highOrderHandleChange = (asset: Asset) => (files: FileList | null) =>
+		handleSourceFieldUpdate(files, asset);
+</script>
+
+<div data-cy="source-container">
+	<h1 class="text-teal-400 px-1">Update sources</h1>
+	<div class="border p-4 mb-6">
+		{#each sources as source}
+			<Source label={source.placeholder} handleChange={highOrderHandleChange(source.asset)} />
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/Form/source/SourceFields.svelte
+++ b/src/lib/components/Form/source/SourceFields.svelte
@@ -2,16 +2,21 @@
 	import type { Asset } from '$lib/ShotstackEditTemplate/types';
 	import Source from './Source.svelte';
 	export let sources: { placeholder: string; asset: Asset }[];
-	export let handleSourceFieldUpdate: (files: FileList | null, asset: Asset) => void;
-	const highOrderHandleChange = (asset: Asset) => (files: FileList | null) =>
-		handleSourceFieldUpdate(files, asset);
+	export let handleSourceFieldUpdate: (files: FileList | null, asset: Asset) => Promise<void>;
+	const highOrderHandleChange = (asset: Asset) => async (files: FileList | null) =>
+		await handleSourceFieldUpdate(files, asset);
 </script>
 
 <div data-cy="source-container" class:hidden={sources.length < 1}>
 	<h1 class="text-teal-400 px-1">Update sources</h1>
 	<div class="border p-4 mb-6">
 		{#each sources as source}
-			<Source label={source.placeholder} handleChange={highOrderHandleChange(source.asset)} />
+			<Source
+				label={source.placeholder}
+				handleChange={highOrderHandleChange(source.asset)}
+				value={source.asset.src}
+				asset={source.asset}
+			/>
 		{/each}
 	</div>
 </div>

--- a/src/lib/components/Form/source/SourceFields.svelte
+++ b/src/lib/components/Form/source/SourceFields.svelte
@@ -7,7 +7,7 @@
 		handleSourceFieldUpdate(files, asset);
 </script>
 
-<div data-cy="source-container">
+<div data-cy="source-container" class:hidden={sources.length < 1}>
 	<h1 class="text-teal-400 px-1">Update sources</h1>
 	<div class="border p-4 mb-6">
 		{#each sources as source}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -95,10 +95,11 @@ class Shotstack {
 				new Source({
 					target: container,
 					props: {
-						label: source.placeholder,
+						value: source.asset.src,
 						asset: source.asset,
-						handleChange: (files: FileList | null) => {
-							this.templateService.updateSrc(files, source.asset);
+						label: source.placeholder,
+						handleChange: async (files: FileList | null) => {
+							await this.templateService.updateSrc(files, source.asset);
 						}
 					}
 				})

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -90,6 +90,19 @@ class Shotstack {
 					}
 				})
 		);
+		this.templateService.getSrcPlaceholders().forEach(
+			(source) =>
+				new Source({
+					target: container,
+					props: {
+						label: source.placeholder,
+						asset: source.asset,
+						handleChange: (files: FileList | null) => {
+							this.templateService.updateSrc(files, source.asset);
+						}
+					}
+				})
+		);
 		return container.children as HTMLCollectionOf<HTMLInputElement>;
 	}
 


### PR DESCRIPTION
# Summary 
- Creates Sourcefield component, which accumulates a Source component for every property with placeholder variables in the source template.
- Sourcefield hides when there's no src property with a placeholder value
- Updates default json in order to demo the new elements
- Updates getInputs (and therefore renderElements) to return a collection of Text Input and Labels for every merge field, and a collection of file inputs, text inputs, and labels for every src property with placeholders
- upload callback now accepts a Promise that resolves into a string, which is used to update the source value and the resulting template.
- Updates snapshots

# Evidence
![image](https://user-images.githubusercontent.com/55909151/199883216-398c7379-8221-4af9-9220-6bb7e4c2e0cd.png)
![image](https://user-images.githubusercontent.com/55909151/199883227-69cc5e5f-d191-4afa-8b06-46a1086027c2.png)
