### PR TITLE
Test: adds component testing for SourceField component

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -3,9 +3,15 @@ import type {
 	IParsedEditSchema,
 	IShotstackEvents,
 	IShotstackHandlers,
-	MergeField
+	MergeField,
+	Placeholder
 } from './types';
-import { validateError, validateTemplate, stringifyIfNotString } from './validate';
+import {
+	validateError,
+	validateTemplate,
+	stringifyIfNotString,
+	removeCurlyBraces
+} from './validate';
 
 export class ShotstackEditTemplateService {
 	public template: IParsedEditSchema;
@@ -116,17 +122,18 @@ export class ShotstackEditTemplateService {
 		return this.result.merge.find(finderCallback);
 	}
 
-	getSrcPlaceholders(): { placeholder: string; asset: Asset }[] {
+	getSrcPlaceholders(): Placeholder[] {
 		if (!this.template.timeline || !this.template.timeline.tracks) return [];
 		const tracks = this.template.timeline.tracks;
-		const result: { placeholder: string; asset: Asset }[] = [];
+		const result: Placeholder[] = [];
 		for (let i = 0; i < tracks.length; i++) {
 			for (let j = 0; j < tracks[i].clips.length; j++) {
-				const key = {
+				const key: Placeholder = {
 					placeholder: tracks[i].clips[j].asset.src,
 					asset: tracks[i].clips[j].asset
 				};
-				if (key.placeholder !== undefined && key.placeholder.charAt(0) === '{') result.push(key);
+				const isPlaceholderValue = removeCurlyBraces(key.placeholder) !== key.placeholder;
+				isPlaceholderValue && result.push(key);
 			}
 		}
 		return result;

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -53,3 +53,8 @@ export type Timeline = {
 	tracks: Track[];
 	[key: string]: unknown;
 };
+
+export type Placeholder = {
+	asset: Asset;
+	placeholder: string;
+};

--- a/src/lib/components/Form/source/Source.test.ts
+++ b/src/lib/components/Form/source/Source.test.ts
@@ -7,7 +7,6 @@ import { jest } from '@jest/globals';
 describe('source/Source.svelte', () => {
 	const textInputAriaLabel = 'Current source value';
 	const fileInputAriaLabel = 'File upload';
-
 	const asset: Asset = {
 		src: '{{ VALUE }}'
 	};
@@ -17,7 +16,6 @@ describe('source/Source.svelte', () => {
 	const handleChange = async (): Promise<void> => {
 		mock();
 	};
-
 	test('Should render Source component', () => {
 		const source = render(Source, { asset, label, handleChange, value });
 		expect(source.getByRole('button')).toBeInTheDocument();

--- a/src/lib/components/Form/source/SourceFields.svelte
+++ b/src/lib/components/Form/source/SourceFields.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import type { Asset } from '$lib/ShotstackEditTemplate/types';
+	import type { Placeholder } from '../../../ShotstackEditTemplate/types';
+	import type { SourceFieldsCallback } from './utils';
+	import { highOrderHandleChange } from './utils';
 	import Source from './Source.svelte';
-	export let sources: { placeholder: string; asset: Asset }[];
-	export let handleSourceFieldUpdate: (files: FileList | null, asset: Asset) => Promise<void>;
-	const highOrderHandleChange = (asset: Asset) => async (files: FileList | null) =>
-		await handleSourceFieldUpdate(files, asset);
+	export let sources: Placeholder[];
+	export let handleSourceFieldUpdate: SourceFieldsCallback;
 </script>
 
 <div data-cy="source-container" class:hidden={sources.length < 1}>
@@ -13,7 +13,7 @@
 		{#each sources as source}
 			<Source
 				label={source.placeholder}
-				handleChange={highOrderHandleChange(source.asset)}
+				handleChange={highOrderHandleChange(source.asset, handleSourceFieldUpdate)}
 				value={source.asset.src}
 				asset={source.asset}
 			/>

--- a/src/lib/components/Form/source/SourceFields.test.ts
+++ b/src/lib/components/Form/source/SourceFields.test.ts
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import SourceFields from './SourceFields.svelte';
+import type { Placeholder } from '../../../ShotstackEditTemplate/types';
+import { jest } from '@jest/globals';
+
+describe('source/SourceFields.svelte', () => {
+	const value = '{{ VALUE }}';
+	const anotherValue = '{{ ANOTHER_VALUE }}';
+	const sources: Placeholder[] = [
+		{ asset: { src: value }, placeholder: value },
+		{ asset: { src: anotherValue }, placeholder: anotherValue }
+	];
+	const mock = jest.fn();
+	const handleSourceFieldUpdate = async () => {
+		mock;
+	};
+	it('Should render SourceFields', () => {
+		const sourceFields = render(SourceFields, { sources, handleSourceFieldUpdate });
+		expect(sourceFields.getByText('Update sources')).toBeInTheDocument();
+	});
+	it('Should render a source component for each element in sources prop', () => {
+		const sourceFields = render(SourceFields, { sources, handleSourceFieldUpdate });
+		expect(sourceFields.getAllByRole('button')).toHaveLength(2);
+		expect(sourceFields.getByText('VALUE')).toBeInTheDocument();
+		expect(sourceFields.getByText('ANOTHER_VALUE')).toBeInTheDocument();
+	});
+	it("Should add a 'hidden' class when sources array is empty", () => {
+		const sources: Placeholder[] = [];
+		const sourceFields = render(SourceFields, { sources, handleSourceFieldUpdate });
+		expect(sourceFields.container.querySelector('[data-cy=source-container]')).toHaveClass(
+			'hidden'
+		);
+	});
+});

--- a/src/lib/components/Form/source/utils.test.ts
+++ b/src/lib/components/Form/source/utils.test.ts
@@ -1,0 +1,15 @@
+import type { Asset } from '../../../ShotstackEditTemplate/types';
+import { highOrderHandleChange, type SourceFieldsCallback } from './utils';
+
+describe('source/utils.ts', () => {
+	describe('.highOrderHandleChange', () => {
+		it('Given an asset and a callback, should return a new function that receives files and calls the callback with the asset and the files', () => {
+			const asset: Asset = { src: '{{ VALUE }} ' };
+			const mock = jest.fn();
+			const fn = highOrderHandleChange(asset, mock);
+			const files = null;
+			fn(files);
+			expect(mock).toHaveBeenCalledWith(files, asset);
+		});
+	});
+});

--- a/src/lib/components/Form/source/utils.ts
+++ b/src/lib/components/Form/source/utils.ts
@@ -1,0 +1,6 @@
+import type { Asset } from '../../../ShotstackEditTemplate/types';
+
+export type SourceFieldsCallback = (files: FileList | null, asset: Asset) => Promise<void>;
+export const highOrderHandleChange =
+	(asset: Asset, fn: SourceFieldsCallback) => async (files: FileList | null) =>
+		await fn(files, asset);


### PR DESCRIPTION
# Summary
- Adds Placeholder type for elements that contain placeholder values and corresponding assets
- Refactors getSrcPlaceholder, to implement Placeholder type and placeholder validation
- Adds component testing for SourceField.svelte and related functions

 # Test evidence
![image](https://user-images.githubusercontent.com/55909151/201200090-69dbe324-5631-4a52-94e8-05d0d3dffe51.png)
![image](https://user-images.githubusercontent.com/55909151/201200117-b15da846-8507-4f55-83d3-ff72bbcb9ac1.png)
