### PR TITLE
Test: adds component testing for ErrorField and Reset component

### DIFF
--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -34,6 +34,7 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
          
         <div
           class="hidden"
+          data-cy="error-container"
         >
           <p
             class="bg-rose-200 rounded py-2 my-4 px-4"
@@ -316,6 +317,7 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
          
         <div
           class="hidden"
+          data-cy="error-container"
         >
           <p
             class="bg-rose-200 rounded py-2 my-4 px-4"
@@ -598,6 +600,7 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
          
         <div
           class="hidden"
+          data-cy="error-container"
         >
           <p
             class="bg-rose-200 rounded py-2 my-4 px-4"
@@ -880,6 +883,7 @@ exports[`Testing Shotstack module entry point Shotstack.renderForm() should depl
          
         <div
           class="hidden"
+          data-cy="error-container"
         >
           <p
             class="bg-rose-200 rounded py-2 my-4 px-4"

--- a/src/lib/components/Form/error/ErrorField.svelte
+++ b/src/lib/components/Form/error/ErrorField.svelte
@@ -5,7 +5,7 @@
 	$: message = (error && error.message) || '';
 </script>
 
-<div class:hidden={!error}>
+<div data-cy="error-container" class:hidden={!error}>
 	<p data-cy="template-input-error" class="bg-rose-200 rounded py-2 my-4 px-4">
 		<span class="monospace text-orange-900">
 			{message}

--- a/src/lib/components/Form/error/ErrorField.test.ts
+++ b/src/lib/components/Form/error/ErrorField.test.ts
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import { render, waitFor, fireEvent } from '@testing-library/svelte';
+import ErrorField from './ErrorField.svelte';
+
+describe('error/ErrorField.svelte', () => {
+	let onClick: () => void;
+	let error: Error | null;
+	let message: string;
+
+	test('Should render ErrorField component', () => {
+		const errorField = render(ErrorField, { props: { onClick, error } });
+		expect(errorField.getByRole('button')).toBeInTheDocument();
+	});
+	test('should click button', async () => {
+		const onClick = jest.fn();
+		const errorField = render(ErrorField, { props: { onClick, error } });
+		const button = errorField.getByText('Reset');
+		await waitFor(() => {
+			fireEvent.click(button);
+		});
+		expect(onClick).toBeCalled();
+	});
+	test('Should add the hidden class when ErrorField doesnt have error', async () => {
+		const errorField = render(ErrorField, { props: { onClick, error } });
+		expect(errorField.container.querySelector('[data-cy=error-container]')).toHaveClass('hidden');
+	});
+	test('Should remove the hidden class when ErrorField have error', async () => {
+		const mockedError = new Error(message);
+		const errorField = render(ErrorField, { props: { onClick, error: mockedError } });
+		expect(errorField.container.querySelector('[data-cy=error-container]')).not.toHaveClass(
+			'hidden'
+		);
+	});
+});

--- a/src/lib/components/Form/error/ErrorField.test.ts
+++ b/src/lib/components/Form/error/ErrorField.test.ts
@@ -11,7 +11,7 @@ describe('error/ErrorField.svelte', () => {
 		const errorField = render(ErrorField, { props: { onClick, error } });
 		expect(errorField.getByRole('button')).toBeInTheDocument();
 	});
-	test('should click button', async () => {
+	test('Should reset the inputs when you click the button', async () => {
 		const onClick = jest.fn();
 		const errorField = render(ErrorField, { props: { onClick, error } });
 		const button = errorField.getByText('Reset');

--- a/src/lib/components/Form/error/ErrorField.test.ts
+++ b/src/lib/components/Form/error/ErrorField.test.ts
@@ -20,7 +20,7 @@ describe('error/ErrorField.svelte', () => {
 		});
 		expect(onClick).toBeCalled();
 	});
-	test('Should add the hidden class when ErrorField doesnt have error', async () => {
+	test('Should add the hidden class when error prop is null', async () => {
 		const errorField = render(ErrorField, { props: { onClick, error } });
 		expect(errorField.container.querySelector('[data-cy=error-container]')).toHaveClass('hidden');
 	});

--- a/src/lib/components/Form/error/Reset.test.ts
+++ b/src/lib/components/Form/error/Reset.test.ts
@@ -8,7 +8,7 @@ describe('error/Reset.svelte', () => {
 		const reset = render(Reset, { props: { onClick } });
 		expect(reset.getByRole('button')).toBeInTheDocument();
 	});
-	test('Should click button', async () => {
+	test('Should reset the inputs when you click the button', async () => {
 		const onClick = jest.fn();
 		const reset = render(Reset, { props: { onClick } });
 		const button = reset.getByText('Reset');

--- a/src/lib/components/Form/error/Reset.test.ts
+++ b/src/lib/components/Form/error/Reset.test.ts
@@ -1,20 +1,20 @@
 import '@testing-library/jest-dom';
-import { render, screen, waitFor, fireEvent,act } from '@testing-library/svelte';
+import { render, waitFor, fireEvent } from '@testing-library/svelte';
 import Reset from './Reset.svelte';
 
 describe('error/Reset.svelte', () => {
-    let onClick: () => void
-    test('Should render Error component', () => {
-		const reset = render(Reset, {props: {onClick}});
+	let onClick: () => void;
+	test('Should render Error component', () => {
+		const reset = render(Reset, { props: { onClick } });
 		expect(reset.getByRole('button')).toBeInTheDocument();
 	});
-    test('should click button', async () => {
-        const onClick = jest.fn();
-        const reset  = render(Reset, {props: {onClick}});
-        const button = reset.getByText("Reset")
-     await waitFor(() =>{
-            fireEvent.click(button)
-        });
-        expect(onClick).toBeCalled()
-    })
-})
+	test('should click button', async () => {
+		const onClick = jest.fn();
+		const reset = render(Reset, { props: { onClick } });
+		const button = reset.getByText('Reset');
+		await waitFor(() => {
+			fireEvent.click(button);
+		});
+		expect(onClick).toBeCalled();
+	});
+});

--- a/src/lib/components/Form/error/Reset.test.ts
+++ b/src/lib/components/Form/error/Reset.test.ts
@@ -4,11 +4,11 @@ import Reset from './Reset.svelte';
 
 describe('error/Reset.svelte', () => {
 	let onClick: () => void;
-	test('Should render Error component', () => {
+	test('Should render Reset component', () => {
 		const reset = render(Reset, { props: { onClick } });
 		expect(reset.getByRole('button')).toBeInTheDocument();
 	});
-	test('should click button', async () => {
+	test('Should click button', async () => {
 		const onClick = jest.fn();
 		const reset = render(Reset, { props: { onClick } });
 		const button = reset.getByText('Reset');

--- a/src/lib/components/Form/error/Reset.test.ts
+++ b/src/lib/components/Form/error/Reset.test.ts
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent,act } from '@testing-library/svelte';
+import Reset from './Reset.svelte';
+
+describe('error/Reset.svelte', () => {
+    let onClick: () => void
+    test('Should render Error component', () => {
+		const reset = render(Reset, {props: {onClick}});
+		expect(reset.getByRole('button')).toBeInTheDocument();
+	});
+    test('should click button', async () => {
+        const onClick = jest.fn();
+        const reset  = render(Reset, {props: {onClick}});
+        const button = reset.getByText("Reset")
+     await waitFor(() =>{
+            fireEvent.click(button)
+        });
+        expect(onClick).toBeCalled()
+    })
+})


### PR DESCRIPTION
# Summary
 -  Adds component testing for Reset.svelte.
 -  Adds component testing for ErrorField.svelte.
 -  Update snapshots of ErrorField

# Test evidence
![image](https://user-images.githubusercontent.com/109624572/201347811-47976030-38d3-404d-9b55-91b377cec903.png)
![image](https://user-images.githubusercontent.com/109624572/201347828-c8ec0fbe-89cc-4d00-9b37-bd56fad97205.png)

