### PR TITLE
Refactor: split Form.svelte into subcomponents

### DIFF
--- a/cypress/e2e/exists.cy.ts
+++ b/cypress/e2e/exists.cy.ts
@@ -45,7 +45,7 @@ describe('Template input section', () => {
 		// Assert
 		cy.get(templateInputError).should('exist');
 		cy.get(mergeFieldsInputSection).should('not.be.visible');
-		cy.get(resultSection).should('not.exist');
+		cy.get(resultSection).should('not.be.visible');
 
 		// Act
 		cy.get(templateInput).click().clear().type(' 23 ');
@@ -53,7 +53,7 @@ describe('Template input section', () => {
 		// Assert
 		cy.get(templateInputError).should('exist');
 		cy.get(mergeFieldsInputSection).should('not.be.visible');
-		cy.get(resultSection).should('not.exist');
+		cy.get(resultSection).should('not.be.visible');
 
 		// Act
 		cy.get(templateInput).click().clear().type(' asd ');
@@ -61,7 +61,7 @@ describe('Template input section', () => {
 		// Assert
 		cy.get(templateInputError).should('exist');
 		cy.get(mergeFieldsInputSection).should('not.be.visible');
-		cy.get(resultSection).should('not.exist');
+		cy.get(resultSection).should('not.be.visible');
 
 		// Act
 		cy.get(templateInput).click().clear().type('{{} message: "wrong json" } ');
@@ -69,7 +69,7 @@ describe('Template input section', () => {
 		// // Assert
 		cy.get(templateInputError).should('exist');
 		cy.get(mergeFieldsInputSection).should('not.be.visible');
-		cy.get(resultSection).should('not.exist');
+		cy.get(resultSection).should('not.be.visible');
 	});
 });
 

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -193,28 +193,27 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
       </form>
        
       <div
-        class="svelte-r93edu"
         data-cy="result-section"
       >
-        <h1
-          class="text-teal-400 px-1 inline-block mr-2 svelte-r93edu"
+        <label
+          class="text-teal-400 px-1"
+          for="json-input"
         >
           Result
-        </h1>
+        </label>
          
         <abbr
-          class="svelte-r93edu"
           title="Copy to clipboard"
         >
           <img
             alt="copy-button"
-            class="h-4 cursor-pointer inline mb-1 svelte-r93edu"
+            class="h-4 cursor-pointer inline mb-1"
             src="[object Object]"
           />
         </abbr>
          
         <p
-          class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-r93edu"
+          class="h-60 overflow-auto border p-4 whitespace-pre monospace"
           data-cy="result"
         >
           {
@@ -475,28 +474,27 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
       </form>
        
       <div
-        class="svelte-r93edu"
         data-cy="result-section"
       >
-        <h1
-          class="text-teal-400 px-1 inline-block mr-2 svelte-r93edu"
+        <label
+          class="text-teal-400 px-1"
+          for="json-input"
         >
           Result
-        </h1>
+        </label>
          
         <abbr
-          class="svelte-r93edu"
           title="Copy to clipboard"
         >
           <img
             alt="copy-button"
-            class="h-4 cursor-pointer inline mb-1 svelte-r93edu"
+            class="h-4 cursor-pointer inline mb-1"
             src="[object Object]"
           />
         </abbr>
          
         <p
-          class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-r93edu"
+          class="h-60 overflow-auto border p-4 whitespace-pre monospace"
           data-cy="result"
         >
           {
@@ -757,28 +755,27 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
       </form>
        
       <div
-        class="svelte-r93edu"
         data-cy="result-section"
       >
-        <h1
-          class="text-teal-400 px-1 inline-block mr-2 svelte-r93edu"
+        <label
+          class="text-teal-400 px-1"
+          for="json-input"
         >
           Result
-        </h1>
+        </label>
          
         <abbr
-          class="svelte-r93edu"
           title="Copy to clipboard"
         >
           <img
             alt="copy-button"
-            class="h-4 cursor-pointer inline mb-1 svelte-r93edu"
+            class="h-4 cursor-pointer inline mb-1"
             src="[object Object]"
           />
         </abbr>
          
         <p
-          class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-r93edu"
+          class="h-60 overflow-auto border p-4 whitespace-pre monospace"
           data-cy="result"
         >
           {
@@ -977,28 +974,27 @@ exports[`Testing Shotstack module entry point Shotstack.renderForm() should depl
       </form>
        
       <div
-        class="svelte-r93edu"
         data-cy="result-section"
       >
-        <h1
-          class="text-teal-400 px-1 inline-block mr-2 svelte-r93edu"
+        <label
+          class="text-teal-400 px-1"
+          for="json-input"
         >
           Result
-        </h1>
+        </label>
          
         <abbr
-          class="svelte-r93edu"
           title="Copy to clipboard"
         >
           <img
             alt="copy-button"
-            class="h-4 cursor-pointer inline mb-1 svelte-r93edu"
+            class="h-4 cursor-pointer inline mb-1"
             src="[object Object]"
           />
         </abbr>
          
         <p
-          class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-r93edu"
+          class="h-60 overflow-auto border p-4 whitespace-pre monospace"
           data-cy="result"
         >
           {

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -15,18 +15,18 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
         class="svelte-r93edu"
       >
         <div
-          class="mb-6 svelte-r93edu"
+          class="mb-6"
           data-cy="template-input-section"
         >
           <label
-            class="text-teal-400 px-1 svelte-r93edu"
+            class="text-teal-400 px-1"
             for="json-input"
           >
             Paste template
           </label>
            
           <textarea
-            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-r93edu"
+            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
             data-cy="template-input"
             id="json-input"
           />
@@ -297,18 +297,18 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
         class="svelte-r93edu"
       >
         <div
-          class="mb-6 svelte-r93edu"
+          class="mb-6"
           data-cy="template-input-section"
         >
           <label
-            class="text-teal-400 px-1 svelte-r93edu"
+            class="text-teal-400 px-1"
             for="json-input"
           >
             Paste template
           </label>
            
           <textarea
-            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-r93edu"
+            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
             data-cy="template-input"
             id="json-input"
           />
@@ -579,18 +579,18 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
         class="svelte-r93edu"
       >
         <div
-          class="mb-6 svelte-r93edu"
+          class="mb-6"
           data-cy="template-input-section"
         >
           <label
-            class="text-teal-400 px-1 svelte-r93edu"
+            class="text-teal-400 px-1"
             for="json-input"
           >
             Paste template
           </label>
            
           <textarea
-            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-r93edu"
+            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
             data-cy="template-input"
             id="json-input"
           />
@@ -861,18 +861,18 @@ exports[`Testing Shotstack module entry point Shotstack.renderForm() should depl
         class="svelte-r93edu"
       >
         <div
-          class="mb-6 svelte-r93edu"
+          class="mb-6"
           data-cy="template-input-section"
         >
           <label
-            class="text-teal-400 px-1 svelte-r93edu"
+            class="text-teal-400 px-1"
             for="json-input"
           >
             Paste template
           </label>
            
           <textarea
-            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-r93edu"
+            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
             data-cy="template-input"
             id="json-input"
           />

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -5,11 +5,13 @@
 	import copyRegular from './copy-regular.svg';
 	import { ShotstackEditTemplateService } from '../../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './defaultMerge.json';
-	import type { Asset, IParsedEditSchema, MergeField } from '$lib/ShotstackEditTemplate/types';
+	import { formatJson } from './common/helpers';
+	import type { Asset, IParsedEditSchema, MergeField } from '../../ShotstackEditTemplate/types';
 	import SubmitArea from './submit/SubmitArea.svelte';
 	import Fields from './fields/Fields.svelte';
 	import ErrorField from './error/ErrorField.svelte';
 	import SourceFields from './source/SourceFields.svelte';
+	import Template from './template/Template.svelte';
 
 	export let editTemplateService = new ShotstackEditTemplateService(defaultJSONInput);
 
@@ -34,10 +36,6 @@
 	function handleCopyToClipboardClick() {
 		navigator.clipboard.writeText(JSON.stringify(result));
 		alert('JSON copied to clipboard!');
-	}
-
-	function formatJson(json: IParsedEditSchema) {
-		return JSON.stringify(json, null, 2);
 	}
 
 	function makeBlob(template: IParsedEditSchema) {
@@ -88,17 +86,7 @@
 <div class="shotstack-mergefield-form">
 	<section data-cy="form-container" class="max-w-lg my-4 mx-auto border rounded-xl px-7 py-4">
 		<form>
-			<div data-cy="template-input-section" class="mb-6">
-				<label for="json-input" class="text-teal-400 px-1">Paste template </label>
-				<textarea
-					data-cy="template-input"
-					class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
-					id="json-input"
-					on:input={(e) => handleTemplateInput(e.currentTarget.value)}
-					value={formatJson(template)}
-				/>
-			</div>
-
+			<Template {template} {handleTemplateInput} />
 			<ErrorField {error} onClick={resetSourceTemplate} />
 			<Fields fields={result.merge} {handleFormInput} {addField} {removeField} {error} />
 			<SourceFields {sources} {handleSourceFieldUpdate} />

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -2,16 +2,14 @@
 	import './Form.css';
 	import './styles.css';
 
-	import copyRegular from './copy-regular.svg';
 	import { ShotstackEditTemplateService } from '../../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './defaultMerge.json';
-	import { formatJson } from './common/helpers';
 	import type { Asset, IParsedEditSchema, MergeField } from '../../ShotstackEditTemplate/types';
-	import SubmitArea from './submit/SubmitArea.svelte';
 	import Fields from './fields/Fields.svelte';
 	import ErrorField from './error/ErrorField.svelte';
 	import SourceFields from './source/SourceFields.svelte';
 	import Template from './template/Template.svelte';
+	import Result from './result/Result.svelte';
 
 	export let editTemplateService = new ShotstackEditTemplateService(defaultJSONInput);
 
@@ -31,11 +29,6 @@
 	function handleFormInput(mergeField: MergeField, fieldReference?: MergeField) {
 		editTemplateService.updateResultMergeFields(mergeField, fieldReference);
 		result = editTemplateService.result;
-	}
-
-	function handleCopyToClipboardClick() {
-		navigator.clipboard.writeText(JSON.stringify(result));
-		alert('JSON copied to clipboard!');
 	}
 
 	function makeBlob(template: IParsedEditSchema) {
@@ -91,24 +84,7 @@
 			<Fields fields={result.merge} {handleFormInput} {addField} {removeField} {error} />
 			<SourceFields {sources} {handleSourceFieldUpdate} />
 		</form>
-
-		{#if !error}
-			<div data-cy="result-section">
-				<h1 class="text-teal-400 px-1 inline-block mr-2">Result</h1>
-				<abbr title="Copy to clipboard">
-					<img
-						src={copyRegular}
-						alt="copy-button"
-						class="h-4 cursor-pointer inline mb-1"
-						on:click={handleCopyToClipboardClick}
-					/>
-				</abbr>
-				<p data-cy="result" class="h-60 overflow-auto  border p-4 whitespace-pre monospace">
-					{formatJson(result)}
-				</p>
-				<SubmitArea {submit} {download} />
-			</div>
-		{/if}
+		<Result {submit} {download} {result} {error} />
 	</section>
 </div>
 

--- a/src/lib/components/Form/common/helpers.ts
+++ b/src/lib/components/Form/common/helpers.ts
@@ -1,0 +1,5 @@
+import type { IParsedEditSchema } from '../../../ShotstackEditTemplate/types';
+
+export function formatJson(json: IParsedEditSchema) {
+	return JSON.stringify(json, null, 2);
+}

--- a/src/lib/components/Form/result/Icon.svelte
+++ b/src/lib/components/Form/result/Icon.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { copyToClipboardAndAlert } from './utils.ts';
+	import copyRegular from '../copy-regular.svg';
+</script>
+
+<abbr title="Copy to clipboard">
+	<img
+		src={copyRegular}
+		alt="copy-button"
+		class="h-4 cursor-pointer inline mb-1"
+		on:click={copyToClipboardAndAlert}
+	/>
+</abbr>

--- a/src/lib/components/Form/result/Json.svelte
+++ b/src/lib/components/Form/result/Json.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	export let text: string;
+</script>
+
+<p data-cy="result" class="h-60 overflow-auto  border p-4 whitespace-pre monospace">
+	{text}
+</p>

--- a/src/lib/components/Form/result/Result.svelte
+++ b/src/lib/components/Form/result/Result.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { formatJson } from '../common/helpers';
+	import SubmitArea from '../submit/SubmitArea.svelte';
+	import type { IParsedEditSchema } from '../../../ShotstackEditTemplate/types';
+	import Subtitle from '../template/Subtitle.svelte';
+	import Icon from './Icon.svelte';
+	import Json from './Json.svelte';
+	export let result: IParsedEditSchema;
+	export let download: string | undefined;
+	export let submit: () => void;
+	export let error: Error | null;
+</script>
+
+<div data-cy="result-section" class:hidden={error}>
+	<Subtitle>Result</Subtitle>
+	<Icon />
+	<Json text={formatJson(result)} />
+	<SubmitArea {submit} {download} />
+</div>

--- a/src/lib/components/Form/result/Subtitle.svelte
+++ b/src/lib/components/Form/result/Subtitle.svelte
@@ -1,0 +1,5 @@
+<script lang="ts"></script>
+
+<h1 class="text-teal-400 px-1 inline-block mr-2">
+	<slot />
+</h1>

--- a/src/lib/components/Form/result/utils.ts
+++ b/src/lib/components/Form/result/utils.ts
@@ -1,0 +1,6 @@
+import type { IParsedEditSchema } from '../../../ShotstackEditTemplate/types';
+
+export function copyToClipboardAndAlert(result: IParsedEditSchema) {
+	navigator.clipboard.writeText(JSON.stringify(result));
+	alert('JSON copied to clipboard!');
+}

--- a/src/lib/components/Form/submit/ButtonDownload.test.ts
+++ b/src/lib/components/Form/submit/ButtonDownload.test.ts
@@ -1,0 +1,18 @@
+import ButtonDownload from './ButtonDownload.svelte';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/svelte';
+
+describe('submit/ButtonDownload.svelte', () => {
+	const download = 'http://localhost/';
+	it('Should render the component', () => {
+		const buttonDownload = render(ButtonDownload, { download });
+		expect(buttonDownload.getByText('Download')).toBeInTheDocument();
+	});
+	it('Anchor tag href should download a text file', async () => {
+		const blob = JSON.stringify({ merge: [] });
+		const download = `blob:${escape(blob)}}`;
+		render(ButtonDownload, { download });
+		const anchorText = screen.getByText<HTMLAnchorElement>('Download').href;
+		expect(anchorText).toEqual(download);
+	});
+});

--- a/src/lib/components/Form/submit/ButtonSubmit.test.ts
+++ b/src/lib/components/Form/submit/ButtonSubmit.test.ts
@@ -1,0 +1,19 @@
+import ButtonSubmit from './ButtonSubmit.svelte';
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/svelte';
+
+describe('submit/ButtonSubmit.svelte', () => {
+	const submit = jest.fn();
+	it('Should render a button that accepts a submit prop', () => {
+		const buttonSubmit = render(ButtonSubmit, { submit });
+		expect(buttonSubmit.getByRole('button')).toBeInTheDocument();
+	});
+	it('On click, it should call the submit callback function', async () => {
+		const buttonSubmit = render(ButtonSubmit, { submit });
+		await waitFor(() => {
+			const button = buttonSubmit.getByRole('button');
+			button.click();
+		});
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/components/Form/submit/SubmitArea.test.ts
+++ b/src/lib/components/Form/submit/SubmitArea.test.ts
@@ -1,0 +1,24 @@
+import SubmitArea from './SubmitArea.svelte';
+import '@testing-library/jest-dom';
+import { render, waitFor, screen } from '@testing-library/svelte';
+
+describe('submit/SubmitArea.svelte', () => {
+	const download = `blob:${escape(JSON.stringify({ merge: [] }))}`;
+	const submit = jest.fn();
+	it('Should render a container for the ButtonDownload and Button Submit components', () => {
+		const submitArea = render(SubmitArea, { download, submit });
+		expect(submitArea.getByText('Download')).toBeInTheDocument();
+		expect(submitArea.getByText('Submit')).toBeInTheDocument();
+	});
+	it('Should call the submit function when the Submit button is pressed', async () => {
+		const submitArea = render(SubmitArea, { download, submit });
+		const submitButton = submitArea.getByText('Submit');
+		await waitFor(() => submitButton.click());
+		expect(submit).toHaveBeenCalled();
+	});
+	it('Download button href value should be equal to download prop', () => {
+		render(SubmitArea, { download, submit });
+		const submitButton = screen.getByText<HTMLAnchorElement>('Download');
+		expect(submitButton.href).toEqual(download);
+	});
+});

--- a/src/lib/components/Form/template/Subtitle.svelte
+++ b/src/lib/components/Form/template/Subtitle.svelte
@@ -1,0 +1,3 @@
+<script lang="ts"></script>
+
+<label for="json-input" class="text-teal-400 px-1"><slot /></label>

--- a/src/lib/components/Form/template/Template.svelte
+++ b/src/lib/components/Form/template/Template.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import type { IParsedEditSchema } from '../../../ShotstackEditTemplate/types';
+	import Subtitle from './Subtitle.svelte';
+	import TextArea from './TextArea.svelte';
+	export let template: IParsedEditSchema;
+	export let handleTemplateInput: (input: string) => void;
+</script>
+
+<div data-cy="template-input-section" class="mb-6">
+	<Subtitle>Paste template</Subtitle>
+	<TextArea {template} {handleTemplateInput} />
+</div>

--- a/src/lib/components/Form/template/TextArea.svelte
+++ b/src/lib/components/Form/template/TextArea.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { formatJson } from '../common/helpers';
+	import type { IParsedEditSchema } from '../../../ShotstackEditTemplate/types';
+	export let handleTemplateInput: (input: string) => void;
+	export let template: IParsedEditSchema;
+</script>
+
+<textarea
+	data-cy="template-input"
+	class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
+	id="json-input"
+	on:input={(e) => handleTemplateInput(e.currentTarget.value)}
+	value={formatJson(template)}
+/>


### PR DESCRIPTION
# Summary
- Split submit section, input template section and result section into different components for testing and compartmentalization purposes.

# Evidence
![image](https://user-images.githubusercontent.com/55909151/201436021-99f0ea65-6caf-4a3b-bb5b-fc048b97121f.png)
![image](https://user-images.githubusercontent.com/55909151/201436053-8b1728b6-1de6-4971-986f-c329f9acb69e.png)
