### PR TITLE
Test: adds component testing for add and badge components

### DIFF
--- a/src/lib/components/Form/fields/Add.test.ts
+++ b/src/lib/components/Form/fields/Add.test.ts
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom';
+import type { MergeField } from '../../../ShotstackEditTemplate/types';
+import { fireEvent, render } from '@testing-library/svelte';
+import Add from './Add.svelte';
+
+describe('fields/Add.svelte', () => {
+	const mock = jest.fn();
+	const addField = (field: MergeField) => {
+		mock(field);
+	};
+	it('Should render a section to add Merge Fields to the template', () => {
+		const add = render(Add, { addField });
+		expect(add.getByText('Add a new merge field')).toBeInTheDocument();
+	});
+	it('Should render two inputs, one for the find prop and another for the replace prop', () => {
+		const add = render(Add, { addField });
+		expect(add.getAllByRole('textbox')).toHaveLength(2);
+	});
+	it('Should render a button that, when pressed, calls the addField function', () => {
+		const add = render(Add, { addField });
+		const button = add.getByRole('button');
+		button.click();
+		expect(mock).toHaveBeenCalled();
+	});
+	it('Updating the input values should call the addField function with the new values', () => {
+		const find = 'foo';
+		const replace = 'bar';
+		const mock = jest.fn();
+		const addField = (field: MergeField) => {
+			mock(field);
+		};
+		const add = render(Add, { addField });
+		const fieldInput = add.getByLabelText('MergeField.find');
+		const replaceInput = add.getByLabelText('MergeField.replace');
+		const button = add.getByRole('button');
+		fireEvent.input(fieldInput, { target: { value: find } });
+		fireEvent.input(replaceInput, { target: { value: replace } });
+		button.click();
+		expect(mock).toHaveBeenCalledWith({ find, replace });
+	});
+	it('Focusing on the input boxes should clear the content', () => {
+		const mock = jest.fn();
+		const addField = (field: MergeField) => {
+			mock(field);
+		};
+		const add = render(Add, { addField });
+		const fieldInput = add.getByLabelText('MergeField.find');
+		const replaceInput = add.getByLabelText('MergeField.replace');
+		const button = add.getByRole('button');
+		fieldInput.focus();
+		replaceInput.focus();
+		button.click();
+		expect(mock).toHaveBeenCalledWith({ find: '', replace: '' });
+	});
+});

--- a/src/lib/components/Form/fields/Badge.test.ts
+++ b/src/lib/components/Form/fields/Badge.test.ts
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import Badge from './Badge.svelte';
+
+describe('fields/Badge.svelte', () => {
+	const onClick = jest.fn();
+	const props = { onClick };
+	it('Should render a button element', () => {
+		const badge = render(Badge, props);
+		expect(badge.getByRole('button')).toBeInTheDocument();
+	});
+	it('When pressed, the button should call onClick prop', () => {
+		const badge = render(Badge, props);
+		const button = badge.getByRole('button');
+		button.click();
+		expect(onClick).toHaveBeenCalled();
+	});
+	it('Should have a label that explains what the button does', () => {
+		const badge = render(Badge, props);
+		const button = badge.getByLabelText('Remove field');
+		expect(button).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Summary
Adds component testing for the following components of the Fields section
- Add.svelte
- Badge.svelte

# Evidence
![image](https://user-images.githubusercontent.com/55909151/201950658-a8d9dcf6-7ae5-481d-8806-3888359092bc.png)
![image](https://user-images.githubusercontent.com/55909151/201950690-0214ddf1-2d52-4671-aadc-4f64307362bf.png)
