### PR TITLE
Refactor: implements id to MergeField input component

### DIFF
--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -80,13 +80,14 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
                   <label
                     aria-label="Current label"
                     class="block mb-2 monospace"
-                    for="NAME"
+                    for="mergefield-input-id-0"
                   >
                     NAME
                   </label>
                    
                   <input
                     class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                    id="mergefield-input-id-0"
                     label="NAME"
                     role="textbox"
                     type="text"
@@ -363,13 +364,14 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
                   <label
                     aria-label="Current label"
                     class="block mb-2 monospace"
-                    for="NAME"
+                    for="mergefield-input-id-0"
                   >
                     NAME
                   </label>
                    
                   <input
                     class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                    id="mergefield-input-id-0"
                     label="NAME"
                     role="textbox"
                     type="text"
@@ -646,13 +648,14 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
                   <label
                     aria-label="Current label"
                     class="block mb-2 monospace"
-                    for="NAME"
+                    for="mergefield-input-id-0"
                   >
                     NAME
                   </label>
                    
                   <input
                     class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                    id="mergefield-input-id-0"
                     label="NAME"
                     role="textbox"
                     type="text"

--- a/src/lib/components/Form/fields/Field.svelte
+++ b/src/lib/components/Form/fields/Field.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import Label from './Label.svelte';
 	import Input from './Input.svelte';
-	import type { MergeField } from '$lib/ShotstackEditTemplate/types';
+	import type { MergeField } from '../../../ShotstackEditTemplate/types';
 	export let field: MergeField;
+	export let inputId: string;
 	export let handleFormInput: (field: MergeField, fieldReference?: MergeField) => void;
 </script>
 
 <div data-cy="label-input">
-	<Label find={field.find} />
-	<Input find={field.find} replace={field.replace} {field} {handleFormInput} />
+	<Label find={field.find} {inputId} />
+	<Input find={field.find} replace={field.replace} {field} {handleFormInput} {inputId} />
 </div>

--- a/src/lib/components/Form/fields/Field.test.ts
+++ b/src/lib/components/Form/fields/Field.test.ts
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { MergeField } from '../../../ShotstackEditTemplate/types';
+import Field from './Field.svelte';
+
+describe('fields/Field.svelte', () => {
+	const field: MergeField = { find: 'foo', replace: 'bar' };
+	const mock = jest.fn();
+	const handleFormInput = (field: MergeField, fieldReference?: MergeField) => {
+		mock(field, fieldReference);
+	};
+	const inputId = 'mergefield-input-id-0';
+	const props = { field, handleFormInput, inputId };
+	it('Should render an input and a label', () => {
+		const $field = render(Field, props);
+		const label = $field.getByLabelText(field.find);
+		const input = $field.getByRole('textbox');
+		expect(label).toBeInTheDocument();
+		expect(input).toBeInTheDocument();
+	});
+	it('Label text should be equal to field.find value', () => {
+		const fieldName = 'baz';
+		const $field = render(Field, { ...props, field: { find: fieldName, replace: 'bar' } });
+		const label = $field.getByLabelText(fieldName);
+		expect(label).toBeInTheDocument();
+	});
+	it('On input, it should call passed function prop with current field value and field reference', () => {
+		render(Field, props);
+		const newValue = 'baz';
+		const input = screen.getByRole<HTMLInputElement>('textbox');
+		fireEvent.input(input, { target: { value: newValue } });
+		expect(mock).toHaveBeenCalledWith({ find: field.find, replace: newValue }, field);
+	});
+});

--- a/src/lib/components/Form/fields/Fields.svelte
+++ b/src/lib/components/Form/fields/Fields.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { MergeField } from '$lib/ShotstackEditTemplate/types';
+	import type { MergeField } from '../../../ShotstackEditTemplate/types';
 	import Add from './Add.svelte';
 	import Badge from './Badge.svelte';
 	import Field from './Field.svelte';
@@ -14,9 +14,9 @@
 	<div data-cy="merge-fields-input-section">
 		<h1 class="text-teal-400 px-1">Modify Merge Values</h1>
 		<div class="border p-4 mb-6">
-			{#each fields as field}
+			{#each fields as field, index}
 				<div class="relative">
-					<Field {field} {handleFormInput} />
+					<Field {field} {handleFormInput} inputId={`mergefield-input-id-${index}`} />
 					<Badge onClick={() => removeField(field)} />
 				</div>
 			{/each}

--- a/src/lib/components/Form/fields/Input.svelte
+++ b/src/lib/components/Form/fields/Input.svelte
@@ -3,10 +3,12 @@
 	export let field: MergeField;
 	export let find: string;
 	export let replace: string;
+	export let inputId: string;
 	export let handleFormInput: (updatedField: MergeField, fieldReference: MergeField) => void;
 </script>
 
 <input
+	id={inputId}
 	role="textbox"
 	class="border w-full mb-3 pl-2 py-1 text-stone-500"
 	type="text"

--- a/src/lib/components/Form/fields/Input.test.ts
+++ b/src/lib/components/Form/fields/Input.test.ts
@@ -8,17 +8,19 @@ describe('fields/Input.svelte', () => {
 	const replace = 'World';
 	const newReplace = 'Fizz';
 	const field: MergeField = { find, replace };
+	const inputId = 'mergefield-input-id-0';
 	const mock = jest.fn();
 	const handleFormInput = (field: MergeField, fieldReference: MergeField) => {
 		mock(field, fieldReference);
 	};
+	const props = { field, find, replace, handleFormInput, inputId };
 	test('Should render Input components', () => {
-		const input = render(Input, { props: { field, find, replace, handleFormInput } });
+		const input = render(Input, props);
 		expect(input.getByRole('textbox')).toBeInTheDocument();
 		expect(input.getByRole('textbox')).toHaveValue(replace);
 	});
 	test('Should testing the handleformInput to receive the correct parameters ', () => {
-		render(Input, { props: { field, find, replace, handleFormInput } });
+		render(Input, props);
 		const inputElement: HTMLInputElement = screen.getByRole<HTMLInputElement>('textbox');
 		fireEvent.input(inputElement, { target: { value: newReplace } });
 		expect(mock).toHaveBeenCalledWith({ find: field.find, replace: newReplace }, field);

--- a/src/lib/components/Form/fields/Label.svelte
+++ b/src/lib/components/Form/fields/Label.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	export let find: string;
+	export let inputId: string;
 </script>
 
-<label for={find} class="block mb-2 monospace" aria-label="Current label">
+<label for={inputId} class="block mb-2 monospace" aria-label="Current label">
 	{find}
 </label>

--- a/src/lib/components/Form/fields/Label.test.ts
+++ b/src/lib/components/Form/fields/Label.test.ts
@@ -5,12 +5,14 @@ import Label from './Label.svelte';
 describe('fields/Label.svelte', () => {
 	const textLabelArialLabel = 'Current label';
 	const find = 'text';
+	const inputId = 'mergefield-input-id-0';
+	const props = { find, inputId };
 	test('Should render Label component', () => {
-		const label = render(Label, { find });
+		const label = render(Label, props);
 		expect(label.getByLabelText(textLabelArialLabel)).toBeInTheDocument();
 	});
 	test('Should return a new text when you change the prop find', () => {
-		render(Label, { find });
+		render(Label, props);
 		const labelElement: HTMLLabelElement =
 			screen.getByLabelText<HTMLLabelElement>(textLabelArialLabel);
 		expect(labelElement.textContent).toEqual(find);


### PR DESCRIPTION
# Summary
- According to accessibility rules, label components cannot be used in isolation, and must always be related to a controlled component. Therefore, it is necessary to add an unique id to the controlled input component, and link that id to the label using the for attribute
- Adds testing for the Field component, that works as a container for the Label + Input pair.

# Evidence
![image](https://user-images.githubusercontent.com/55909151/201963939-9dc0a247-4095-4563-8852-444e63399ddc.png)
![image](https://user-images.githubusercontent.com/55909151/201963985-d1bf58e9-56cc-4bad-a815-47ec1a13a391.png)

