### PR TITLE
Bugfix: upload file button now correctly enables again when callback fails

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -143,9 +143,14 @@ export class ShotstackEditTemplateService {
 		let result = asset.src;
 		for (let i = 0; i < this.handlers.upload.length; i++) {
 			const handler = this.handlers.upload[i];
-			result = await handler(files);
+			try {
+				result = await handler(files);
+				if (!result) throw new Error(`Asset URL not found at upload handler index ${i}`);
+				else asset.src = result;
+			} catch (error) {
+				console.error(error);
+			}
 		}
-		asset.src = result;
 		this.handlers.change.forEach((fn) => fn(this.result));
 	}
 }

--- a/src/lib/components/Form/source/Source.svelte
+++ b/src/lib/components/Form/source/Source.svelte
@@ -9,9 +9,14 @@
 	$: disabled = loading;
 	let loadFile = async (files: FileList | null) => {
 		loading = true;
-		await handleChange(files);
-		value = asset.src;
-		loading = false;
+		try {
+			await handleChange(files);
+			value = asset.src;
+		} catch (error) {
+			console.log(error);
+		} finally {
+			loading = false;
+		}
 	};
 </script>
 


### PR DESCRIPTION
# Summary
- When a file is selected to be uploaded using the source field input, if the callback failed, the button would be disabled permanently due to being stuck on the 'loading' mode
- Now the result is not important. At the end of the process it will enable again, whether it finishes or it fails.
- Adds testing for this functionality

# Evidence
![image](https://user-images.githubusercontent.com/55909151/202302395-8530ac02-0110-48c9-9d3e-2b4d56fac2a1.png)
![image](https://user-images.githubusercontent.com/55909151/202302412-8118c3f0-7d65-4c98-9837-092473ae6a4e.png)

